### PR TITLE
issue #49934 Relax some checks tight to CGROUP V1 when running CGROUP V2 

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -250,7 +250,7 @@ echo 'Optional Features:'
 }
 {
 	if [ "$cgroupVersion" = "cgroup" ]; then
-		check_flags CGROUP_PIDS
+		check_flags CGROUP_PIDS CGROUP_HUGETLB
 	fi
 }
 {
@@ -314,7 +314,6 @@ fi
 check_flags \
 	BLK_CGROUP BLK_DEV_THROTTLING \
 	CGROUP_PERF \
-	CGROUP_HUGETLB \
 	NET_CLS_CGROUP $netprio \
 	CFS_BANDWIDTH FAIR_GROUP_SCHED \
 	IP_NF_TARGET_REDIRECT \


### PR DESCRIPTION
This PR implements : https://github.com/moby/moby/issues/49934

This change is inspired by this commit : https://github.com/kubernetes/system-validators/pull/41/files
as well as : https://github.com/k0sproject/k0s/pull/5735/files

**- What I did**
* Verify which cgroup is currently mounted
* Adapt checks depending if running cgroup or cgroup2

**- How to verify it**
* execute the updated script  `contrib/check-config.sh` on RHEL8 / RHEL9 / openSuse MicroOS / openSUSE Tumbleweed

**- Human readable description for the release notes**

```markdown changelog
Relax kernel configuration checks for cgroup v2
```

**- A picture of a cute animal (not mandatory but encouraged)**

